### PR TITLE
feat: Contact-User linking + new deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,30 +6,153 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  DEPLOY_PATH: /home/ubuntu/psychology-website
+
 jobs:
-  deploy:
+  build-and-deploy:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Deploy to VPS via SSH
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, xml, ctype, iconv, intl, pdo_mysql, gd
+          coverage: none
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install Composer dependencies
+        run: |
+          export APP_ENV=prod
+          composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist --no-scripts
+
+      - name: Install Yarn dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build frontend assets
+        run: yarn build
+
+      - name: Create production .env file
+        run: |
+          echo "APP_ENV=prod" > .env.local
+          echo "APP_SECRET=${{ secrets.APP_SECRET }}" >> .env.local
+          echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .env.local
+          echo "JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem" >> .env.local
+          echo "JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem" >> .env.local
+          echo "JWT_PASSPHRASE=${{ secrets.JWT_PASSPHRASE }}" >> .env.local
+          echo "CORS_ALLOW_ORIGIN='^https?://(psychology\.elydris\.fr|localhost)(:[0-9]+)?$'" >> .env.local
+          echo "GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .env.local
+          echo "GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}" >> .env.local
+          echo "GOOGLE_REDIRECT_URI=https://psychology.elydris.fr/connect/google/check" >> .env.local
+
+      - name: Create JWT keys from secrets
+        run: |
+          mkdir -p config/jwt
+          echo "${{ secrets.JWT_PRIVATE_KEY }}" > config/jwt/private.pem
+          echo "${{ secrets.JWT_PUBLIC_KEY }}" > config/jwt/public.pem
+          chmod 644 config/jwt/private.pem
+          chmod 644 config/jwt/public.pem
+
+      - name: Deploy via SSH
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ubuntu
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: 22
+          source: "bin,config,migrations,public,src,templates,vendor,composer.json,symfony.lock,compose.yaml,.env,.env.local"
+          target: ${{ env.DEPLOY_PATH }}
+          overwrite: true
+
+      - name: Execute post-deployment commands
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.VPS_HOST }}
-          username: ${{ secrets.VPS_USER }}
+          username: ubuntu
           key: ${{ secrets.VPS_SSH_KEY }}
-          port: ${{ secrets.VPS_PORT }}
+          port: 22
           script: |
-            cd /home/ubuntu/psychology-website
+            cd ${{ env.DEPLOY_PATH }}
 
-            # Pull latest changes
-            git pull origin main
+            # Créer les dossiers nécessaires
+            mkdir -p var/cache var/log
 
-            # Rebuild and restart containers
-            docker compose -f compose.prod.yaml down
-            docker compose -f compose.prod.yaml build --no-cache
-            docker compose -f compose.prod.yaml up -d
+            # Permissions
+            chmod -R 775 var/
+            chmod 600 config/jwt/private.pem
+            chmod 644 config/jwt/public.pem
 
-            # Run migrations inside container
-            docker compose -f compose.prod.yaml exec -T app php bin/console doctrine:migrations:migrate --no-interaction
+            # Créer le fichier .env pour Docker avec le mot de passe DB
+            echo "MYSQL_PASSWORD=${{ secrets.DB_PASSWORD }}" > .env.docker
+            echo "MYSQL_ROOT_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env.docker
 
-            echo "Deployment completed successfully!"
+            # Démarrer/Redémarrer la base de données MariaDB
+            docker compose --env-file .env.docker up -d
+
+            # Attendre que MariaDB soit prêt
+            echo "Waiting for database..."
+            sleep 20
+
+            # Exécuter les migrations
+            php bin/console doctrine:migrations:migrate --no-interaction --env=prod
+
+            # Vider et réchauffer le cache
+            php bin/console cache:clear --env=prod --no-debug
+            php bin/console cache:warmup --env=prod
+
+            # Créer le service systemd pour PHP si nécessaire
+            sudo tee /etc/systemd/system/psychology-php.service > /dev/null << 'SYSTEMD'
+            [Unit]
+            Description=Psychology Website PHP Server
+            After=network.target docker.service
+
+            [Service]
+            Type=simple
+            User=ubuntu
+            WorkingDirectory=/home/ubuntu/psychology-website
+            ExecStart=/usr/bin/php -S 0.0.0.0:8002 -t public
+            Restart=always
+            RestartSec=5
+            StandardOutput=append:/home/ubuntu/psychology-website/var/log/php-server.log
+            StandardError=append:/home/ubuntu/psychology-website/var/log/php-server.log
+
+            [Install]
+            WantedBy=multi-user.target
+            SYSTEMD
+
+            # Recharger systemd et redémarrer le service
+            sudo systemctl daemon-reload
+            sudo systemctl enable psychology-php
+            sudo systemctl restart psychology-php
+
+            # Vérifier que le serveur a démarré
+            sleep 2
+            if systemctl is-active --quiet psychology-php; then
+              echo "Deployment completed successfully! Server running on port 8002"
+            else
+              echo "Warning: PHP server may not have started correctly"
+              sudo systemctl status psychology-php
+            fi
+
+      - name: Deployment notification
+        run: echo "✅ Deployment to VPS succeeded!"

--- a/assets/react/components/ContactRequestsCard.tsx
+++ b/assets/react/components/ContactRequestsCard.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { useUserContacts, ContactRequest } from '@/hooks/useUserContacts';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  MessageSquare,
+  Clock,
+  CheckCircle2,
+  AlertCircle,
+  Mail,
+  Phone,
+  CalendarClock,
+} from 'lucide-react';
+
+const ContactRequestsCard: React.FC = () => {
+  const { contacts, isLoading, error } = useUserContacts();
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString('fr-FR', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const getConsultationTypeColor = (type: string) => {
+    const colors: Record<string, string> = {
+      'Thérapie individuelle': 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+      'Thérapie de couple': 'bg-pink-100 text-pink-800 dark:bg-pink-900 dark:text-pink-200',
+      "Psychologie de l'enfant": 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+      'Accompagnement professionnel': 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+      'Évaluation psychologique': 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+      'Autre': 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
+    };
+    return colors[type] || colors['Autre'];
+  };
+
+  if (isLoading) {
+    return (
+      <Card className="border-0 shadow-lg mb-8">
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-64 mt-2" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="border-0 shadow-lg mb-8 border-l-4 border-l-destructive">
+        <CardContent className="p-6">
+          <div className="flex items-center gap-3 text-destructive">
+            <AlertCircle className="h-5 w-5" />
+            <p>{error}</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (contacts.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card className="border-0 shadow-lg mb-8 bg-gradient-to-br from-amber-50/50 to-orange-50/50 dark:from-amber-950/20 dark:to-orange-950/20">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-amber-500 rounded-lg">
+            <MessageSquare className="h-5 w-5 text-white" />
+          </div>
+          <div>
+            <CardTitle className="text-lg">Vos demandes de contact</CardTitle>
+            <CardDescription>
+              {contacts.length} demande{contacts.length > 1 ? 's' : ''} envoyée{contacts.length > 1 ? 's' : ''}
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {contacts.map((contact) => (
+          <ContactRequestItem key={contact.id} contact={contact} formatDate={formatDate} getConsultationTypeColor={getConsultationTypeColor} />
+        ))}
+      </CardContent>
+    </Card>
+  );
+};
+
+interface ContactRequestItemProps {
+  contact: ContactRequest;
+  formatDate: (date: string) => string;
+  getConsultationTypeColor: (type: string) => string;
+}
+
+const ContactRequestItem: React.FC<ContactRequestItemProps> = ({
+  contact,
+  formatDate,
+  getConsultationTypeColor,
+}) => {
+  return (
+    <div className="bg-background rounded-lg p-4 shadow-sm border">
+      <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3 mb-3">
+        <div className="flex items-center gap-2">
+          <Badge variant="outline" className={getConsultationTypeColor(contact.consultationType)}>
+            {contact.consultationType}
+          </Badge>
+          {contact.processed ? (
+            <Badge variant="default" className="gap-1 bg-green-600">
+              <CheckCircle2 className="h-3 w-3" />
+              Traitée
+            </Badge>
+          ) : (
+            <Badge variant="secondary" className="gap-1">
+              <Clock className="h-3 w-3" />
+              En attente
+            </Badge>
+          )}
+        </div>
+        <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+          <CalendarClock className="h-4 w-4" />
+          <span>{formatDate(contact.createdAt)}</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-sm mb-3">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Mail className="h-4 w-4" />
+          <span>{contact.email}</span>
+        </div>
+        {contact.phone && (
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Phone className="h-4 w-4" />
+            <span>{contact.phone}</span>
+          </div>
+        )}
+      </div>
+
+      {contact.message && (
+        <div className="bg-muted/50 rounded-md p-3 text-sm">
+          <p className="text-muted-foreground italic">"{contact.message}"</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ContactRequestsCard;

--- a/assets/react/hooks/useUserContacts.tsx
+++ b/assets/react/hooks/useUserContacts.tsx
@@ -1,0 +1,76 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+
+export interface ContactRequest {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string | null;
+  consultationType: string;
+  message: string | null;
+  createdAt: string;
+  processed: boolean;
+}
+
+interface UseUserContactsReturn {
+  contacts: ContactRequest[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+export function useUserContacts(): UseUserContactsReturn {
+  const { user } = useAuth();
+  const [contacts, setContacts] = useState<ContactRequest[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchContacts = useCallback(async () => {
+    const token = localStorage.getItem('auth_token');
+
+    if (!user || !token) {
+      setContacts([]);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/me/contacts', {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          setError('Session expirée');
+          return;
+        }
+        throw new Error('Erreur lors de la récupération des demandes');
+      }
+
+      const data = await response.json();
+      setContacts(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Une erreur est survenue');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    fetchContacts();
+  }, [fetchContacts]);
+
+  return {
+    contacts,
+    isLoading,
+    error,
+    refetch: fetchContacts,
+  };
+}

--- a/assets/react/pages/Appointments.tsx
+++ b/assets/react/pages/Appointments.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import ContactRequestsCard from '@/components/ContactRequestsCard';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -213,6 +214,9 @@ const Appointments: React.FC = () => {
       <Header />
       <div className="min-h-screen bg-gradient-to-br from-background via-background to-accent/5 py-8 pt-24">
         <div className="container mx-auto px-4 max-w-6xl">
+        {/* Demandes de contact */}
+        <ContactRequestsCard />
+
         {/* Header */}
         <div className="mb-8">
           <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,8 +6,8 @@ services:
     environment:
       MYSQL_DATABASE: psychology
       MYSQL_USER: psychology
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-defaultpassword}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-defaultpassword}
     ports:
       - "3306:3306"
     volumes:

--- a/migrations/Version20260120153052.php
+++ b/migrations/Version20260120153052.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260120153052 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add user_id foreign key to contact table for Contact-User relationship';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE contact ADD user_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE contact ADD CONSTRAINT FK_4C62E638A76ED395 FOREIGN KEY (user_id) REFERENCES `user` (id)');
+        $this->addSql('CREATE INDEX IDX_4C62E638A76ED395 ON contact (user_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE contact DROP FOREIGN KEY FK_4C62E638A76ED395');
+        $this->addSql('DROP INDEX IDX_4C62E638A76ED395 ON contact');
+        $this->addSql('ALTER TABLE contact DROP user_id');
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -9,6 +9,8 @@ use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
 use ApiPlatform\Metadata\Patch;
 use App\Repository\UserRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -75,10 +77,15 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     #[Groups(['user:read'])]
     private bool $isVerified = false;
 
+    /** @var Collection<int, Contact> */
+    #[ORM\OneToMany(mappedBy: 'user', targetEntity: Contact::class)]
+    private Collection $contacts;
+
     public function __construct()
     {
         $this->createdAt = new \DateTimeImmutable();
         $this->roles = ['ROLE_USER'];
+        $this->contacts = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -207,6 +214,35 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     public function setGoogleId(?string $googleId): static
     {
         $this->googleId = $googleId;
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Contact>
+     */
+    public function getContacts(): Collection
+    {
+        return $this->contacts;
+    }
+
+    public function addContact(Contact $contact): static
+    {
+        if (!$this->contacts->contains($contact)) {
+            $this->contacts->add($contact);
+            $contact->setUser($this);
+        }
+
+        return $this;
+    }
+
+    public function removeContact(Contact $contact): static
+    {
+        if ($this->contacts->removeElement($contact)) {
+            if ($contact->getUser() === $this) {
+                $contact->setUser(null);
+            }
+        }
+
         return $this;
     }
 }

--- a/src/EventSubscriber/UserRegistrationSubscriber.php
+++ b/src/EventSubscriber/UserRegistrationSubscriber.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use App\Entity\Contact;
+use App\Entity\User;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Events;
+
+/**
+ * Listener déclenché après la création d'un User.
+ * Lie automatiquement les contacts existants qui ont le même email.
+ */
+#[AsEntityListener(event: Events::postPersist, method: 'postPersist', entity: User::class)]
+class UserRegistrationSubscriber
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function postPersist(User $user): void
+    {
+        // Chercher tous les contacts avec le même email qui ne sont pas encore liés
+        $contacts = $this->entityManager->getRepository(Contact::class)->findBy([
+            'email' => $user->getEmail(),
+            'user' => null,
+        ]);
+
+        if (empty($contacts)) {
+            return;
+        }
+
+        // Lier chaque contact trouvé au nouvel utilisateur
+        foreach ($contacts as $contact) {
+            $contact->setUser($user);
+        }
+
+        $this->entityManager->flush();
+    }
+}

--- a/src/State/ContactStateProcessor.php
+++ b/src/State/ContactStateProcessor.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Entity\Contact;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * State Processor pour la création de Contact.
+ * Lie automatiquement le contact à un utilisateur existant si l'email correspond.
+ */
+class ContactStateProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @param Contact $data
+     */
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): Contact
+    {
+        // Chercher si un utilisateur existe avec cet email
+        $user = $this->entityManager->getRepository(User::class)->findOneBy([
+            'email' => $data->getEmail()
+        ]);
+
+        // Si un utilisateur est trouvé, lier le contact à cet utilisateur
+        if ($user !== null) {
+            $data->setUser($user);
+        }
+
+        // Persister le contact
+        $this->entityManager->persist($data);
+        $this->entityManager->flush();
+
+        return $data;
+    }
+}


### PR DESCRIPTION
## Summary
- Automatic linking of Contact messages to existing Users by email
- When a new user registers, their previous contact messages are linked automatically
- Display user's contact requests on the Appointments page
- New deployment workflow: native PHP + Docker MariaDB (no Docker for app)

## Changes

### Backend
- Add `ManyToOne` relationship from Contact to User
- Create `ContactStateProcessor` for auto-linking on contact creation
- Create `UserRegistrationSubscriber` for linking contacts on registration
- Add `GET /api/me/contacts` endpoint for user's contact messages
- Secure Contact endpoints (admin only for GET)

### Frontend
- New `ContactRequestsCard` component
- New `useUserContacts` hook
- Display contact requests above appointments list

### Deployment
- Build assets in CI (not on VPS)
- PHP server via systemd on port 8002
- MariaDB remains in Docker
- Secrets via GitHub Secrets

## Test plan
- [ ] Create contact without account, then register with same email → contacts linked
- [ ] Create contact with existing account email → contact linked immediately
- [ ] View contact requests on /appointments page
- [ ] Deploy to VPS and verify server runs on port 8002

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)